### PR TITLE
Update release file with automatic path versioning and pre-release logic

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,19 +1,64 @@
-name: Release lib-ml
+name: Auto Bump Patch + Release lib-ml
 
 on:
   push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+    branches:
+      - main
 
 permissions:
   contents: write
 
 jobs:
-  build-package:
+  bump-build-release:
+    if: ${{ !contains(github.event.head_commit.message, 'Bump version to') }}
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Fetch tags and bump patch version
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          echo "Latest tag: $LATEST_TAG"
+
+          if [ -z "$LATEST_TAG" ]; then
+            NEW_TAG="v0.0.1"
+          else
+            VERSION=${LATEST_TAG#v}
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | cut -d. -f3)
+            NEW_TAG="v$MAJOR.$MINOR.$((PATCH + 1))"
+          fi
+
+          NEW_VERSION=${NEW_TAG#v}
+          echo "$NEW_VERSION" > version.txt
+          git add version.txt
+          git commit -m "Update version.txt to $NEW_VERSION"
+          git push origin main
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+
+      - name: Set version env
+        id: parse-version
+        run: |
+          VERSION=$(cat version.txt)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_ENV
+  
+  build-and-release:
+    needs: bump-build-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -35,7 +80,44 @@ jobs:
       - name: Upload package artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ env.version }}
+          generate_release_notes: true
           files: |
             dist/*.whl
-            dist/*.tar.gz        
+            dist/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bump-pre-release:
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Compute next pre-release version
+        run: |
+          CURRENT_VERSION=$(cat version.txt)
+          MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT_VERSION" | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          TIMESTAMP=$(date -u +"%Y%m%d.%H%M")
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-pre.${TIMESTAMP}"
+          echo "$NEXT_VERSION" > version.txt
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_ENV
+
+      - name: Commit and push pre-release version
+        run: |
+          git add version.txt
+          git diff --quiet && echo "No changes to commit" || git commit -m "Bump version to ${{ env.next_version }} after release ${{ needs.build-and-release.outputs.version }}"
+          git push origin main        
 


### PR DESCRIPTION
Remaining requirements from A1 are implemented for correct versioning.

Good requirements:
- Automatic increase of Patch versions is enabled. This closes #8.
- After a stable release, main is set to a pre-release version that is higher than the latest release. This closes #7.

Excellent requirement:
- The automation supports to release multiple versions of the same pre-release. This closes #9.